### PR TITLE
Feat #1: Add page routing and basic navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.2",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -3538,6 +3539,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -16213,6 +16223,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,24 @@
-import logo from './logo.svg';
-import './App.css';
+import { BrowserRouter as Router, Route, Routes, Link } from 'react-router-dom';
+import Home from './pages/Home';
+import GroupList from './pages/GroupList';
+import CreatePost from './pages/CreatePost';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Router>
+      <nav>
+        <ul>
+          <li><Link to="/">Home</Link></li>
+          <li><Link to="/groups">Groups</Link></li>
+          <li><Link to="/create-post">Create Post</Link></li>
+        </ul>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/groups" element={<GroupList />} />
+        <Route path="/create-post" element={<CreatePost />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/src/pages/CreatePost.js
+++ b/src/pages/CreatePost.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const CreatePost = () => {
+  return (
+    <div>
+      <h1>Create Post</h1>
+    </div>
+  );
+};
+
+export default CreatePost;

--- a/src/pages/GroupList.js
+++ b/src/pages/GroupList.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const GroupList = () => {
+  return (
+    <div>
+      <h1>Group List</h1>
+    </div>
+  );
+};
+
+export default GroupList;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Home = () => {
+  return (
+    <div>
+      <h1>Home Page</h1>
+    </div>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
이 Pull Request는 다음의 작업을 포함합니다:

- React Router를 이용해 페이지 라우팅을 설정하였습니다.
- Home, GroupList, CreatePost의 기본 페이지를 구현하고, 각 페이지 간의 네비게이션을 추가하였습니다.
- 기본 네비게이션 메뉴를 통해 각 페이지로 이동할 수 있도록 설정하였습니다.
  
## 구현된 기능:
1. **홈 페이지**: 기본적인 Home 페이지 텍스트 표시.
2. **그룹 리스트 페이지**: 그룹 리스트 페이지 틀 구성.
3. **게시글 작성 페이지**: 게시글 작성 페이지 틀 구성.
4. **네비게이션**: 상단 네비게이션 바를 추가하여 각 페이지로 이동할 수 있도록 설정.

## 참고 사항:
- 이 PR은 페이지 라우팅과 기본적인 페이지 틀을 구현하는 초기 작업입니다.
- 이후 추가적인 기능을 구현할 때 각 페이지의 구체적인 내용이 업데이트될 예정입니다.