### PR TITLE
Feat #3: 그룹 목록 조회 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
@@ -5819,6 +5820,31 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15838,6 +15864,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <link rel="stylesheet" href="https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/pages/GroupList.css
+++ b/src/pages/GroupList.css
@@ -1,0 +1,149 @@
+/* 전체 레이아웃 */
+.group-list-container {
+  width: 100%;
+  max-width: 1560px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+/* 헤더 */
+.group-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.logo-container {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.logo {
+  width: 137px; /* 로고 사이즈 */
+}
+
+.create-group-btn {
+  background-color: #282828;
+  color: white;
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 700;
+  font-size: 14px;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+/* 공개/비공개 및 검색바 */
+.group-list-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+}
+
+.privacy-toggle {
+  display: flex;
+  gap: 10px;
+}
+
+.public-btn, .private-btn {
+  background-color: #FAFAFA;
+  color: #282828;
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 700;
+  font-size: 14px;
+  padding: 10px 15px;
+  border: 1px solid #B8B8B8;
+  border-radius: 20px;
+  cursor: pointer;
+}
+
+.public-btn.active, .private-btn.active {
+  background-color: #282828;
+  color: #FAFAFA;
+}
+
+.search-input {
+  width: 1186px;
+  height: 45px;
+  border: 1px solid #B8B8B8;
+  border-radius: 20px;
+  padding-left: 15px;
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.sort-select {
+  padding: 10px;
+  border-radius: 5px;
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 400;
+  font-size: 14px;
+}
+
+/* 그룹 카드 레이아웃 */
+.group-cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr); /* 한 줄에 4개 */
+  gap: 20px;
+}
+
+/* 그룹 카드 */
+.group-card {
+  border: 1px solid #B8B8B8;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.group-card-img {
+  width: 100%;
+  height: 180px; /* 이미지 높이 */
+  object-fit: cover;
+}
+
+.group-card-info {
+  padding: 15px;
+}
+
+.group-card-header {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 400;
+  font-size: 14px;
+  color: #282828;
+}
+
+.public, .private {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.group-title {
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 700;
+  font-size: 16px;
+  color: #282828;
+  margin: 10px 0;
+}
+
+.group-description {
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 400;
+  font-size: 14px;
+  color: #282828;
+}
+
+.group-stats {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Spoqa Han Sans Neo';
+  font-weight: 400;
+  font-size: 12px;
+  color: #B8B8B8;
+}

--- a/src/pages/GroupList.js
+++ b/src/pages/GroupList.js
@@ -1,9 +1,123 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import './GroupList.css'; // 스타일링 적용
 
 const GroupList = () => {
+  const navigate = useNavigate();
+  
+  // 그룹 데이터 (목업 데이터)
+  const groups = [
+    {
+      id: 1,
+      title: '에델바이스',
+      description: '서로 한 마음으로 응원하고 아끼는 달봉이네 가족입니다.',
+      badges: 2,
+      memories: 8,
+      likes: 1500,
+      dDay: 265,
+      isPublic: true,
+      imgSrc: 'edelweiss-public.png', // 공개 그룹의 대표 이미지
+    },
+    {
+      id: 2,
+      title: '안개꽃',
+      description: '작은 순간을 함께 기억하는 꽃같은 우리들',
+      badges: 5,
+      memories: 10,
+      likes: 2300,
+      dDay: 180,
+      isPublic: false, // 비공개 그룹의 경우 이미지를 출력하지 않음
+    },
+    // 추가 목업 그룹 데이터
+  ];
+
+  const [isPublicSelected, setIsPublicSelected] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sortCriteria, setSortCriteria] = useState('likes');
+
+  // 공개/비공개 토글
+  const togglePublicGroups = () => setIsPublicSelected(true);
+  const togglePrivateGroups = () => setIsPublicSelected(false);
+
+  // 그룹 필터링 (공개/비공개)
+  const filteredGroups = groups
+    .filter(group => group.isPublic === isPublicSelected)
+    .filter(group => group.title.toLowerCase().includes(searchTerm.toLowerCase()));
+
+  // 정렬 기준에 따른 그룹 정렬
+  const sortedGroups = [...filteredGroups].sort((a, b) => {
+    if (sortCriteria === 'likes') return b.likes - a.likes;
+    if (sortCriteria === 'badges') return b.badges - a.badges;
+    if (sortCriteria === 'memories') return b.memories - a.memories;
+    if (sortCriteria === 'recent') return b.dDay - a.dDay;
+    return 0;
+  });
+
   return (
-    <div>
-      <h1>Group List</h1>
+    <div className="group-list-container">
+      {/* 상단 헤더 */}
+      <header className="group-list-header">
+        <div className="logo-container">
+          <img src="/jogakzip1.svg" alt="조각집 로고" className="logo" />
+        </div>
+        <button className="create-group-btn" onClick={() => navigate('/create-group')}>그룹 만들기</button>
+      </header>
+
+      {/* 필터, 검색 및 정렬 옵션 */}
+      <div className="group-list-controls">
+        <div className="privacy-toggle">
+          <button className={`public-btn ${isPublicSelected ? 'active' : ''}`} onClick={togglePublicGroups}>공개</button>
+          <button className={`private-btn ${!isPublicSelected ? 'active' : ''}`} onClick={togglePrivateGroups}>비공개</button>
+        </div>
+        <input
+          type="text"
+          placeholder="그룹명을 검색해 주세요"
+          className="search-input"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+        <select
+          className="sort-select"
+          value={sortCriteria}
+          onChange={(e) => setSortCriteria(e.target.value)}
+        >
+          <option value="likes">공감순</option>
+          <option value="badges">획득 배지순</option>
+          <option value="memories">게시글 많은순</option>
+          <option value="recent">최신순</option>
+        </select>
+      </div>
+
+      {/* 그룹 카드 리스트 */}
+      <div className="group-cards">
+        {sortedGroups.map((group) => (
+          <div key={group.id} className="group-card">
+            {/* 공개 그룹일 때만 이미지를 출력 */}
+            {group.isPublic && (
+              <img
+                src={group.imgSrc}  // 공개 그룹 이미지 출력
+                alt={group.title}
+                className="group-card-img"
+              />
+            )}
+            <div className="group-card-info">
+              <div className="group-card-header">
+                <span>D+{group.dDay}</span>
+                <span className={group.isPublic ? 'public' : 'private'}>
+                  {group.isPublic ? '공개' : '비공개'}
+                </span>
+              </div>
+              <h3 className="group-title">{group.title}</h3>
+              <p className="group-description">{group.description}</p>
+              <div className="group-stats">
+                <span>획득 배지 {group.badges}</span>
+                <span>추억 {group.memories}</span>
+                <span>그룹 공감 {group.likes.toLocaleString()}K</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### 그룹 목록 조회 페이지 기능 구현
- 그룹 목록 조회 UI 구현 (공개/비공개 그룹 구분)
- 공개 그룹의 경우 등록된 대표 이미지 출력
- 비공개 그룹의 경우 이미지 미출력
- 그룹명 검색, 정렬 기능 추가 (공감순, 게시글 많은순, 획득 배지순, 최신순)
- "그룹 만들기" 버튼 클릭 시 CreateGroup 페이지로